### PR TITLE
Properly compute normals when transformations are involved

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -189,6 +189,16 @@ class Normal:
         """Convert a normal into a :class:`Vec` type"""
         return Vec(self.x, self.y, self.z)
 
+    def squared_norm(self):
+        return self.x * self.x + self.y * self.y + self.z * self.z
+
+    def norm(self):
+        return math.sqrt(self.squared_norm())
+
+    def normalize(self):
+        norm = self.norm()
+        return Normal(self.x / norm, self.y / norm, self.z / norm)
+
 
 VEC_X = Vec(1.0, 0.0, 0.0)
 VEC_Y = Vec(0.0, 1.0, 0.0)

--- a/shapes.py
+++ b/shapes.py
@@ -107,7 +107,7 @@ class Sphere(Shape):
         hit_point = inv_ray.at(first_hit_t)
         return HitRecord(
             world_point=self.transformation * hit_point,
-            normal=self.transformation * _sphere_normal(hit_point, ray.dir),
+            normal=self.transformation * _sphere_normal(hit_point, inv_ray.dir),
             surface_point=_sphere_point_to_uv(hit_point),
             t=first_hit_t,
             ray=ray,

--- a/test_all.py
+++ b/test_all.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 
 from copy import deepcopy
-from math import pi
+from math import pi, sqrt
 
 import unittest
 from io import BytesIO
@@ -84,7 +84,7 @@ class TestColor(unittest.TestCase):
 
 
 # fmt: off
-        
+
 # This is the content of "reference_le.pfm" (little-endian file)
 LE_REFERENCE_BYTES = bytes(
     [
@@ -118,6 +118,7 @@ BE_REFERENCE_BYTES = bytes(
         0xB4, 0x00, 0x00,
     ]
 )
+
 
 # fmt: on
 
@@ -630,6 +631,14 @@ class TestSphere(unittest.TestCase):
 
         # Check if the *inverse* transformation was wrongly applied
         assert not sphere.ray_intersection(Ray(origin=Point(-10, 0, 0), dir=-VEC_Z))
+
+    def testNormals(self):
+        sphere = Sphere(transformation=scaling(Vec(2.0, 1.0, 1.0)))
+
+        ray = Ray(origin=Point(1.0, 1.0, 0.0), dir=Vec(-1.0, -1.0))
+        intersection = sphere.ray_intersection(ray)
+        # We normalize "intersection.normal", as we are not interested in its length
+        assert intersection.normal.normalize().is_close(Normal(1.0, 4.0, 0.0).normalize())
 
 
 if __name__ == "__main__":

--- a/test_all.py
+++ b/test_all.py
@@ -640,6 +640,16 @@ class TestSphere(unittest.TestCase):
         # We normalize "intersection.normal", as we are not interested in its length
         assert intersection.normal.normalize().is_close(Normal(1.0, 4.0, 0.0).normalize())
 
+    def testNormalDirection(self):
+        # Scaling a sphere by -1 keeps the sphere the same but reverses its
+        # reference frame
+        sphere = Sphere(transformation=scaling(Vec(-1.0, -1.0, -1.0)))
+
+        ray = Ray(origin=Point(0.0, 2.0, 0.0), dir=-VEC_Y)
+        intersection = sphere.ray_intersection(ray)
+        # We normalize "intersection.normal", as we are not interested in its length
+        assert intersection.normal.normalize().is_close(Normal(0.0, 1.0, 0.0).normalize())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR corrects the way normals are computed in sphere-ray intersections. It should fix bug #6.