### PR TITLE
Properly compute UV coordinates in ray-sphere intersections

### DIFF
--- a/shapes.py
+++ b/shapes.py
@@ -33,8 +33,9 @@ from transformations import Transformation
 
 def _sphere_point_to_uv(point: Point) -> Vec2d:
     """Convert a 3D point on the surface of the unit sphere into a (u, v) 2D point"""
+    u = atan2(point.y, point.x) / (2.0 * pi)
     return Vec2d(
-        u=atan2(point.y, point.x) / (2.0 * pi),
+        u=u if u >= 0.0 else u + 1.0,
         v=acos(point.z) / pi,
     )
 

--- a/test_all.py
+++ b/test_all.py
@@ -650,6 +650,49 @@ class TestSphere(unittest.TestCase):
         # We normalize "intersection.normal", as we are not interested in its length
         assert intersection.normal.normalize().is_close(Normal(0.0, 1.0, 0.0).normalize())
 
+    def testUVCoordinates(self):
+        sphere = Sphere()
+
+        # The first four rays hit the unit sphere at the
+        # points P1, P2, P3, and P4.
+        #
+        #                    ^ y
+        #                    | P2
+        #              , - ~ * ~ - ,
+        #          , '       |       ' ,
+        #        ,           |           ,
+        #       ,            |            ,
+        #      ,             |             , P1
+        # -----*-------------+-------------*---------> x
+        #   P3 ,             |             ,
+        #       ,            |            ,
+        #        ,           |           ,
+        #          ,         |        , '
+        #            ' - , _ * _ ,  '
+        #                    | P4
+        #
+        # P5 and P6 are aligned along the x axis and are displaced
+        # along z (ray5 in the positive direction, ray6 in the negative
+        # direction).
+
+        ray1 = Ray(origin=Point(2.0, 0.0, 0.0), dir=-VEC_X)
+        assert sphere.ray_intersection(ray1).surface_point.is_close(Vec2d(0.0, 0.5))
+
+        ray2 = Ray(origin=Point(0.0, 2.0, 0.0), dir=-VEC_Y)
+        assert sphere.ray_intersection(ray2).surface_point.is_close(Vec2d(0.25, 0.5))
+
+        ray3 = Ray(origin=Point(-2.0, 0.0, 0.0), dir=VEC_X)
+        assert sphere.ray_intersection(ray3).surface_point.is_close(Vec2d(0.5, 0.5))
+
+        ray4 = Ray(origin=Point(0.0, -2.0, 0.0), dir=VEC_Y)
+        assert sphere.ray_intersection(ray4).surface_point.is_close(Vec2d(0.75, 0.5))
+
+        ray5 = Ray(origin=Point(2.0, 0.0, 0.5), dir=-VEC_X)
+        assert sphere.ray_intersection(ray5).surface_point.is_close(Vec2d(0.0, 1 / 3))
+
+        ray6 = Ray(origin=Point(2.0, 0.0, -0.5), dir=-VEC_X)
+        assert sphere.ray_intersection(ray6).surface_point.is_close(Vec2d(0.0, 2 / 3))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes the way UV coordinates on the surface of a sphere are computed in ray intersections. It should fix bug #7.
