### PR TITLE
Implement a path tracer

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -18,6 +18,8 @@
 
 import math
 from dataclasses import dataclass
+from typing import Tuple, Union
+
 from misc import are_close
 
 
@@ -220,3 +222,21 @@ class Vec2d:
     def is_close(self, other: "Vec2d", epsilon=1e-5):
         """Check whether two `Vec2d` points are roughly the same or not"""
         return (abs(self.u - other.u) < epsilon) and (abs(self.v - other.v) < epsilon)
+
+
+def create_onb_from_z(normal: Union[Vec, Normal]) -> Tuple[Vec, Vec, Vec]:
+    """Create a orthonormal basis (ONB) from a vector representing the z axis (normalized)
+
+    Return a tuple containing the three vectors (e1, e2, e3) of the basis. The result is such
+    that e3 = normal.
+
+    The `normal` vector must be *normalized*, otherwise this method won't work.
+    """
+    sign = 1.0 if (normal.z > 0.0) else -1.0
+    a = -1.0 / (sign + normal.z)
+    b = normal.x * normal.y * a
+
+    e1 = Vec(1.0 + sign * normal.x * normal.x * a, sign * b, -sign * normal.x)
+    e2 = Vec(b, sign + normal.y * normal.y * a, -normal.y)
+
+    return e1, e2, normal.to_vec()

--- a/geometry.py
+++ b/geometry.py
@@ -182,6 +182,10 @@ class Normal:
     def __neg__(self):
         return Normal(-self.x, -self.y, -self.z)
 
+    def __mul__(self, scalar):
+        """Compute the product between a vector and a scalar"""
+        return _mul_scalar_xyz(scalar=scalar, xyz=self, return_type=Normal)
+
     def is_close(self, other, epsilon=1e-5):
         """Return True if the object and 'other' have roughly the same direction and orientation"""
         assert isinstance(other, Normal)

--- a/geometry.py
+++ b/geometry.py
@@ -125,6 +125,7 @@ class Vec:
         self.x /= norm
         self.y /= norm
         self.z /= norm
+        return self
 
 
 @dataclass

--- a/geometry.py
+++ b/geometry.py
@@ -196,8 +196,12 @@ class Normal:
         return math.sqrt(self.squared_norm())
 
     def normalize(self):
+        """Modify the vector's norm so that it becomes equal to 1"""
         norm = self.norm()
-        return Normal(self.x / norm, self.y / norm, self.z / norm)
+        self.x /= norm
+        self.y /= norm
+        self.z /= norm
+        return self
 
 
 VEC_X = Vec(1.0, 0.0, 0.0)

--- a/geometry.py
+++ b/geometry.py
@@ -243,4 +243,4 @@ def create_onb_from_z(normal: Union[Vec, Normal]) -> Tuple[Vec, Vec, Vec]:
     e1 = Vec(1.0 + sign * normal.x * normal.x * a, sign * b, -sign * normal.x)
     e2 = Vec(b, sign + normal.y * normal.y * a, -normal.y)
 
-    return e1, e2, normal.to_vec()
+    return e1, e2, Vec(normal.x, normal.y, normal.z)

--- a/geometry.py
+++ b/geometry.py
@@ -203,3 +203,16 @@ class Normal:
 VEC_X = Vec(1.0, 0.0, 0.0)
 VEC_Y = Vec(0.0, 1.0, 0.0)
 VEC_Z = Vec(0.0, 0.0, 1.0)
+
+
+@dataclass
+class Vec2d:
+    """A 2D vector used to represent a point on a surface
+
+    The fields are named `u` and `v` to distinguish them from the usual 3D coordinates `x`, `y`, `z`."""
+    u: float = 0.0
+    v: float = 0.0
+
+    def is_close(self, other: "Vec2d", epsilon=1e-5):
+        """Check whether two `Vec2d` points are roughly the same or not"""
+        return (abs(self.u - other.u) < epsilon) and (abs(self.v - other.v) < epsilon)

--- a/hdrimages.py
+++ b/hdrimages.py
@@ -212,7 +212,7 @@ def _parse_endianness(line: str):
         raise InvalidPfmFileFormat("invalid endianness specification")
 
 
-def read_pfm_image(stream):
+def read_pfm_image(stream) -> HdrImage:
     """Read a PFM image from a stream
 
     Return a ``HdrImage`` object containing the image. If an error occurs, raise a

--- a/hitrecord.py
+++ b/hitrecord.py
@@ -19,21 +19,8 @@
 from dataclasses import dataclass
 from typing import Union
 
-from geometry import Point, Normal
+from geometry import Point, Normal, Vec2d
 from ray import Ray
-
-
-@dataclass
-class Vec2d:
-    """A 2D vector used to represent a point on a surface
-
-    The fields are named `u` and `v` to distinguish them from the usual 3D coordinates `x`, `y`, `z`."""
-    u: float = 0.0
-    v: float = 0.0
-
-    def is_close(self, other: "Vec2d", epsilon=1e-5):
-        """Check whether two `Vec2d` points are roughly the same or not"""
-        return (abs(self.u - other.u) < epsilon) and (abs(self.v - other.v) < epsilon)
 
 
 @dataclass

--- a/hitrecord.py
+++ b/hitrecord.py
@@ -41,6 +41,7 @@ class HitRecord:
     surface_point: Vec2d
     t: float
     ray: Ray
+    shape: "Shape"
 
     def is_close(self, other: Union["HitRecord", None], epsilon=1e-5) -> bool:
         """Check whether two `HitRecord` represent the same hit event or not"""

--- a/hitrecord.py
+++ b/hitrecord.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import Union
 
 from geometry import Point, Normal, Vec2d
+from materials import Material
 from ray import Ray
 
 
@@ -41,7 +42,7 @@ class HitRecord:
     surface_point: Vec2d
     t: float
     ray: Ray
-    shape: "Shape"
+    material: Material
 
     def is_close(self, other: Union["HitRecord", None], epsilon=1e-5) -> bool:
         """Check whether two `HitRecord` represent the same hit event or not"""

--- a/imagetracer.py
+++ b/imagetracer.py
@@ -50,7 +50,15 @@ class ImageTracer:
 
         For each pixel in the :class:`.HdrImage` object fire one ray, and pass it to the function `func`, which
         must accept a :class:`.Ray` as its only parameter and must return a :class:`.Color` instance telling the
-        color to assign to that pixel in the image."""
+        color to assign to that pixel in the image.
+
+        If `callback` is not none, it must be a function accepting at least two parameters named `col` and `row`.
+        This function is called periodically during the rendering, and the two mandatory arguments are the row and
+        column number of the last pixel that has been traced. (Both the row and column are increased by one starting
+        from zero: first the row and then the column.) The time between two consecutive calls to the callback can be
+        tuned using the parameter `callback_time_s`. Any keyword argument passed to `fire_all_rays` is passed to the
+        callback.
+        """
         last_call_time = process_time()
         callback(0, 0, **callback_kwargs)
         for row in range(self.image.height):
@@ -61,5 +69,5 @@ class ImageTracer:
 
                 current_time = process_time()
                 if callback and (current_time - last_call_time > callback_time_s):
-                    callback(row, col, **callback_kwargs)
+                    callback(col=col, row=row, **callback_kwargs)
                     last_call_time = current_time

--- a/imagetracer.py
+++ b/imagetracer.py
@@ -60,7 +60,9 @@ class ImageTracer:
         callback.
         """
         last_call_time = process_time()
-        callback(0, 0, **callback_kwargs)
+        if callback:
+            callback(col=0, row=0, **callback_kwargs)
+
         for row in range(self.image.height):
             for col in range(self.image.width):
                 ray = self.fire_ray(col, row)

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@
 # IN THE SOFTWARE.
 
 from dataclasses import dataclass
+import sys
 
 from hdrimages import HdrImage, Endianness, read_pfm_image
 from camera import OrthogonalCamera, PerspectiveCamera
@@ -27,6 +28,8 @@ from ray import Ray
 from shapes import Sphere
 from transformations import translation, scaling, rotation_z
 from world import World
+from materials import UniformPigment, CheckeredPigment, ImagePigment, DiffuseBRDF, Material
+from render import OnOffRenderer, FlatRenderer
 
 import click
 
@@ -44,10 +47,14 @@ def cli():
     pass
 
 
+RENDERERS = ["onoff", "flat"]
+
+
 @click.command("demo")
 @click.option("--width", type=int, default=640, help="Width of the image to render")
 @click.option("--height", type=int, default=480, help="Height of the image to render")
 @click.option("--angle-deg", type=float, default=0.0, help="Angle of view")
+@click.option('--algorithm', type=click.Choice(RENDERERS), default="flat")
 @click.option(
     "--pfm-output",
     type=str,
@@ -65,11 +72,27 @@ def cli():
     is_flag=True,
     help="Use an orthogonal camera instead of a perspective camera",
 )
-def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
-    image = HdrImage(width, height)
-
+def demo(width, height, angle_deg, algorithm, orthogonal, pfm_output, png_output):
     # Create a world and populate it with a few shapes
     world = World()
+
+    material1 = Material(
+        brdf=DiffuseBRDF(UniformPigment(Color(0.7, 0.3, 0.2)))
+    )
+
+    material2 = Material(
+        brdf=DiffuseBRDF(CheckeredPigment(Color(0.2, 0.7, 0.3), Color(0.3, 0.2, 0.7), num_of_steps=4)),
+    )
+
+    sphere_texture = HdrImage(2, 2)
+    sphere_texture.set_pixel(0, 0, Color(0.1, 0.2, 0.3))
+    sphere_texture.set_pixel(0, 1, Color(0.2, 0.1, 0.3))
+    sphere_texture.set_pixel(1, 0, Color(0.3, 0.2, 0.1))
+    sphere_texture.set_pixel(1, 1, Color(0.3, 0.1, 0.2))
+
+    material3 = Material(
+        brdf=DiffuseBRDF(ImagePigment(sphere_texture))
+    )
 
     for x in [-0.5, 0.5]:
         for y in [-0.5, 0.5]:
@@ -77,7 +100,8 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
                 world.add(
                     Sphere(
                         transformation=translation(Vec(x, y, z))
-                                       * scaling(Vec(0.1, 0.1, 0.1))
+                                       * scaling(Vec(0.1, 0.1, 0.1)),
+                        material=material1,
                     )
                 )
 
@@ -87,14 +111,19 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
     world.add(
         Sphere(
             transformation=translation(Vec(0.0, 0.0, -0.5))
-                           * scaling(Vec(0.1, 0.1, 0.1))
+                           * scaling(Vec(0.1, 0.1, 0.1)),
+            material=material2,
         )
     )
+
     world.add(
         Sphere(
-            transformation=translation(Vec(0.0, 0.5, 0.0)) * scaling(Vec(0.1, 0.1, 0.1))
+            transformation=translation(Vec(0.0, 0.5, 0.0)) * scaling(Vec(0.1, 0.1, 0.1)),
+            material=material3,
         )
     )
+
+    image = HdrImage(width, height)
 
     # Initialize a camera
     camera_tr = rotation_z(angle_deg=angle_deg) * translation(Vec(-1.0, 0.0, 0.0))
@@ -109,13 +138,17 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
 
     tracer = ImageTracer(image=image, camera=camera)
 
-    def compute_color(ray: Ray) -> Color:
-        if world.ray_intersection(ray):
-            return WHITE
-        else:
-            return BLACK
+    if algorithm == "onoff":
+        print("Using on/off renderer")
+        renderer = OnOffRenderer(world=world, background_color=BLACK)
+    elif algorithm == "flat":
+        print("Using flat renderer")
+        renderer = FlatRenderer(world=world, background_color=BLACK)
+    else:
+        print(f"Unknown renderer: {algorithm}")
+        sys.exit(1)
 
-    tracer.fire_all_rays(compute_color)
+    tracer.fire_all_rays(renderer)
 
     # Save the HDR image
     with open(pfm_output, "wb") as outf:
@@ -123,7 +156,7 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
     print(f"HDR demo image written to {pfm_output}")
 
     # Apply tone-mapping to the image
-    image.normalize_image(factor=1.0)
+    image.normalize_image(factor=0.3)
     image.clamp_image()
 
     # Save the LDR image
@@ -133,12 +166,10 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
 
 
 @click.command("pfm2png")
-@click.option("--factor", type=float, default=0.2, help="Multiplicative factor")
-@click.option(
-    "--gamma", type=float, default=1.0, help="Value to be used for gamma correction"
-)
-@click.argument("input_pfm_file_name")
-@click.argument("output_png_file_name")
+@click.option("--factor", type=float, default=0.7, help="Multiplicative factor")
+@click.option("--gamma", type=float, default=1.0, help="Exponent for gamma-correction")
+@click.argument("input_pfm_file_name", type=str)
+@click.argument("output_png_file_name", type=str)
 def pfm2png(factor, gamma, input_pfm_file_name, output_png_file_name):
     with open(input_pfm_file_name, "rb") as inpf:
         img = read_pfm_image(inpf)

--- a/main.py
+++ b/main.py
@@ -38,30 +38,6 @@ class Parameters:
     gamma: float = 1.0
     output_png_file_name: str = ""
 
-    def parse_command_line(self, argv):
-        if len(sys.argv) != 5:
-            raise RuntimeError(
-                "Usage: main.py INPUT_PFM_FILE FACTOR GAMMA OUTPUT_PNG_FILE"
-            )
-
-        self.input_pfm_file_name = sys.argv[1]
-
-        try:
-            self.factor = float(sys.argv[2])
-        except ValueError:
-            raise RuntimeError(
-                f"Invalid factor ('{sys.argv[2]}'), it must be a floating-point number."
-            )
-
-        try:
-            self.gamma = float(sys.argv[3])
-        except ValueError:
-            raise RuntimeError(
-                f"Invalid gamma ('{sys.argv[3]}'), it must be a floating-point number."
-            )
-
-        self.output_png_file_name = sys.argv[4]
-
 
 @click.group()
 def cli():
@@ -101,7 +77,7 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
                 world.add(
                     Sphere(
                         transformation=translation(Vec(x, y, z))
-                        * scaling(Vec(0.1, 0.1, 0.1))
+                                       * scaling(Vec(0.1, 0.1, 0.1))
                     )
                 )
 
@@ -111,7 +87,7 @@ def demo(width, height, angle_deg, orthogonal, pfm_output, png_output):
     world.add(
         Sphere(
             transformation=translation(Vec(0.0, 0.0, -0.5))
-            * scaling(Vec(0.1, 0.1, 0.1))
+                           * scaling(Vec(0.1, 0.1, 0.1))
         )
     )
     world.add(

--- a/main.py
+++ b/main.py
@@ -124,6 +124,7 @@ def demo(width, height, angle_deg, algorithm, orthogonal, pfm_output, png_output
     )
 
     image = HdrImage(width, height)
+    print(f"Generating a {width}×{height} image, with the camera tilted by {angle_deg}°")
 
     # Initialize a camera
     camera_tr = rotation_z(angle_deg=angle_deg) * translation(Vec(-1.0, 0.0, 0.0))
@@ -168,15 +169,16 @@ def demo(width, height, angle_deg, algorithm, orthogonal, pfm_output, png_output
 @click.command("pfm2png")
 @click.option("--factor", type=float, default=0.7, help="Multiplicative factor")
 @click.option("--gamma", type=float, default=1.0, help="Exponent for gamma-correction")
+@click.option("--luminosity", type=float, default=None, help="Average luminosity")
 @click.argument("input_pfm_file_name", type=str)
 @click.argument("output_png_file_name", type=str)
-def pfm2png(factor, gamma, input_pfm_file_name, output_png_file_name):
+def pfm2png(factor, gamma, luminosity, input_pfm_file_name, output_png_file_name):
     with open(input_pfm_file_name, "rb") as inpf:
         img = read_pfm_image(inpf)
 
     print(f"File {input_pfm_file_name} has been read from disk.")
 
-    img.normalize_image(factor=factor)
+    img.normalize_image(factor=factor, luminosity=luminosity)
     img.clamp_image()
 
     with open(output_png_file_name, "wb") as outf:

--- a/materials.py
+++ b/materials.py
@@ -117,13 +117,13 @@ class DiffuseBRDF(BRDF):
     def scatter_ray(self, pcg: PCG, incoming_dir: Vec, interaction_point: Point, normal: Normal, depth: int):
         # Cosine-weighted distribution around the z (local) axis
         e1, e2, e3 = create_onb_from_z(normal)
-        r1 = 2.0 * pi * pcg.random_float()
-        r2 = pcg.random_float()
-        r2sqrt = sqrt(r2)
+        cos_theta_sq = pcg.random_float()
+        cos_theta, sin_theta = sqrt(cos_theta_sq), sqrt(1.0 - cos_theta_sq)
+        phi = 2.0 * pi * pcg.random_float()
 
         return Ray(
             origin=interaction_point,
-            dir=e1 * cos(r1) * r2sqrt + e2 * sin(r1) * r2sqrt + e3 * sqrt(1.0 - r2),
+            dir=e1 * cos(phi) * cos_theta + e2 * sin(phi) * cos_theta + e3 * sin_theta,
             tmin=1.0e-3,
             tmax=inf,
             depth=depth,

--- a/materials.py
+++ b/materials.py
@@ -16,6 +16,7 @@
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from dataclasses import dataclass
 from math import floor, pi
 
 from colors import Color, BLACK, WHITE

--- a/materials.py
+++ b/materials.py
@@ -1,0 +1,114 @@
+# -*- encoding: utf-8 -*-
+#
+# The MIT License (MIT)
+#
+# Copyright © 2021 Maurizio Tomasi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+# LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from math import floor, pi
+
+from colors import Color, BLACK, WHITE
+from geometry import Normal, Vec, Vec2d
+from hdrimages import HdrImage
+
+
+class Pigment:
+    """A «pigment»
+
+    This abstract class represents a pigment, i.e., a function that associates a color with
+    each point on a parametric surface (u,v). Call the method :meth:`.Pigment.get_color` to
+    retrieve the color of the surface given a :class:`.Vec2d` object."""
+
+    def get_color(self, uv: Vec2d) -> Color:
+        """Return the color of the pigment at the specified coordinates"""
+        raise NotImplementedError("Method Pigment.get_color is abstract and cannot be called")
+
+
+class UniformPigment(Pigment):
+    """A uniform pigment
+
+    This is the most boring pigment: a uniform hue over the whole surface."""
+
+    def __init__(self, color=Color()):
+        self.color = color
+
+    def get_color(self, uv: Vec2d) -> Color:
+        return self.color
+
+
+class ImagePigment(Pigment):
+    """A textured pigment
+
+    The texture is given through a PFM image."""
+
+    def __init__(self, image: HdrImage):
+        self.image = image
+
+    def get_color(self, uv: Vec2d) -> Color:
+        col = int(uv.u * self.image.width)
+        row = int(uv.v * self.image.height)
+
+        if col >= self.image.width:
+            col = self.image.width - 1
+
+        if row >= self.image.height:
+            row = self.image.height - 1
+
+        # A nicer solution would implement bilinear interpolation to reduce pixelization artifacts
+        # See https://en.wikipedia.org/wiki/Bilinear_interpolation
+        return self.image.get_pixel(col, row)
+
+
+class CheckeredPigment(Pigment):
+    """A checkered pigment
+
+    The number of rows/columns in the checkered pattern is tunable, but you cannot have a different number of
+    repetitions along the u/v directions."""
+
+    def __init__(self, color1: Color, color2: Color, num_of_steps=10):
+        self.color1 = color1
+        self.color2 = color2
+        self.num_of_steps = num_of_steps
+
+    def get_color(self, uv: Vec2d) -> Color:
+        int_u = int(floor(uv.u * self.num_of_steps))
+        int_v = int(floor(uv.v * self.num_of_steps))
+
+        return self.color1 if ((int_u % 2) == (int_v % 2)) else self.color2
+
+
+class BRDF:
+    """An abstract class representing a Bidirectional Reflectance Distribution Function"""
+    def __init__(self, pigment: Pigment = UniformPigment(WHITE)):
+        self.pigment = pigment
+
+    def eval(self, normal: Normal, in_dir: Vec, out_dir: Vec, uv: Vec2d) -> Color:
+        return BLACK
+
+
+class DiffuseBRDF(BRDF):
+    """A class representing an ideal diffuse BRDF (also called «Lambertian»)"""
+    def __init__(self, pigment: Pigment = UniformPigment(WHITE), reflectance: float = 1.0):
+        super().__init__(pigment)
+        self.reflectance = reflectance
+
+    def eval(self, normal: Normal, in_dir: Vec, out_dir: Vec, uv: Vec2d) -> Color:
+        return self.pigment.get_color(uv) * (self.reflectance / pi)
+
+
+@dataclass
+class Material:
+    """A material"""
+    brdf: BRDF = DiffuseBRDF()
+    emitted_radiance: Pigment = UniformPigment(BLACK)

--- a/pcg.py
+++ b/pcg.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+
+from dataclasses import dataclass
+
+
+# The routines to_uint64 and to_uint32 are needed in Python, as it does
+# not have the concept of "typed integers". In other languages like C++
+# it is enough to declare a variable as `uint32_t` or `uint64_t`, and
+# clipping will be done automatically by the CPU/virtual machine.
+
+def to_uint64(x: int) -> int:
+    """Clip an integer so that it occupies 64 bits"""
+    return x & 0xffffffffffffffff
+
+
+def to_uint32(x: int) -> int:
+    """Clip an integer so that it occupies 32 bits"""
+    return x & 0xffffffff
+
+
+@dataclass
+class PCG:
+    """PCG Uniform Pseudo-random Number Generator"""
+    state: int = 0
+    inc: int = 0
+
+    def __init__(self, init_state=42, init_seq=54):
+        # 64-bit
+        self.state = 0
+
+        # 64-bit
+        self.inc = (init_seq << 1) | 1
+
+        self.random()
+
+        # 64-bit
+        self.state += init_state
+
+        self.random()
+
+    def random(self):
+        """Return a new random number and advance PCG's internal state"""
+        # 64-bit
+        oldstate = self.state
+
+        # 64-bit
+        self.state = to_uint64((oldstate * 6364136223846793005 + self.inc))
+
+        # 32-bit
+        xorshifted = to_uint32((((oldstate >> 18) ^ oldstate) >> 27))
+
+        # 32-bit
+        rot = oldstate >> 59
+
+        # 32-bit
+        return to_uint32((xorshifted >> rot) | (xorshifted << ((-rot) & 31)))

--- a/pcg.py
+++ b/pcg.py
@@ -54,3 +54,7 @@ class PCG:
 
         # 32-bit
         return to_uint32((xorshifted >> rot) | (xorshifted << ((-rot) & 31)))
+
+    def random_float(self):
+        """Return a new random number uniformly distributed over [0, 1]"""
+        return self.random() / 0xffffffff

--- a/render.py
+++ b/render.py
@@ -1,0 +1,69 @@
+# -*- encoding: utf-8 -*-
+#
+# The MIT License (MIT)
+#
+# Copyright © 2021 Maurizio Tomasi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+# LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from colors import Color, WHITE, BLACK
+from ray import Ray
+from world import World
+
+
+class Renderer:
+    """A class implementing a solver of the rendering equation.
+
+    This is an abstract class; you should use a derived concrete class."""
+
+    def __init__(self, world: World, background_color: Color = BLACK):
+        self.world = world
+        self.background_color = background_color
+
+    def __call__(self, ray: Ray) -> Color:
+        """Estimate the radiance along a ray"""
+        raise NotImplementedError("Unable to call Renderer.radiance, it is an abstract method")
+
+
+class OnOffRenderer(Renderer):
+    """A on/off renderer
+
+    This renderer is mostly useful for debugging purposes, as it is really fast, but it produces boring images."""
+
+    def __init__(self, world: World, background_color: Color = BLACK, color=WHITE):
+        super().__init__(world, background_color)
+        self.world = world
+        self.color = color
+
+    def __call__(self, ray: Ray) -> Color:
+        return self.color if self.world.ray_intersection(ray) else self.background_color
+
+
+class FlatRenderer(Renderer):
+    """A «flat» renderer
+
+    This renderer estimates the solution of the rendering equation by neglecting any contribution of the light.
+    It just uses the pigment of each surface to determine how to compute the final radiance."""
+
+    def __init__(self, world: World, background_color: Color = BLACK):
+        super().__init__(world, background_color)
+
+    def __call__(self, ray: Ray) -> Color:
+        hit = self.world.ray_intersection(ray)
+        if not hit:
+            return self.background_color
+
+        material = hit.shape.material
+
+        return (material.brdf.pigment.get_color(hit.surface_point) +
+                material.emitted_radiance.get_color(hit.surface_point))

--- a/render.py
+++ b/render.py
@@ -64,7 +64,7 @@ class FlatRenderer(Renderer):
         if not hit:
             return self.background_color
 
-        material = hit.shape.material
+        material = hit.material
 
         return (material.brdf.pigment.get_color(hit.surface_point) +
                 material.emitted_radiance.get_color(hit.surface_point))
@@ -94,7 +94,7 @@ class PathTracer(Renderer):
         if not hit_record:
             return self.background_color
 
-        hit_material = hit_record.shape.material
+        hit_material = hit_record.material
         hit_color = hit_material.brdf.pigment.get_color(hit_record.surface_point)
         emitted_radiance = hit_material.emitted_radiance.get_color(hit_record.surface_point)
 
@@ -112,7 +112,13 @@ class PathTracer(Renderer):
         cum_radiance = Color(0.0, 0.0, 0.0)
         if hit_color_lum > 0.0:  # Only do costly recursions if it's worth it
             for ray_index in range(self.num_of_rays):
-                new_ray = hit_material.brdf.scatter_ray(self.pcg, hit_record, ray.depth + 1)
+                new_ray = hit_material.brdf.scatter_ray(
+                    pcg=self.pcg,
+                    incoming_dir=hit_record.ray.dir,
+                    interaction_point=hit_record.world_point,
+                    normal=hit_record.normal,
+                    depth=ray.depth + 1,
+                )
                 # Recursive call
                 new_radiance = self(new_ray)
                 cum_radiance += hit_color * new_radiance

--- a/shapes.py
+++ b/shapes.py
@@ -77,9 +77,9 @@ class Shape:
 class Sphere(Shape):
     """A 3D unit sphere centered on the origin of the axes"""
 
-    def __init__(self, transformation=Transformation()):
+    def __init__(self, transformation=Transformation(), material: Material = Material()):
         """Create a unit sphere, potentially associating a transformation to it"""
-        super().__init__(transformation)
+        super().__init__(transformation, material)
 
     def ray_intersection(self, ray: Ray) -> Union[HitRecord, None]:
         """Checks if a ray intersects the sphere

--- a/shapes.py
+++ b/shapes.py
@@ -29,6 +29,7 @@ from geometry import Point, Vec, Normal
 from hitrecord import Vec2d, HitRecord
 from ray import Ray
 from transformations import Transformation
+from materials import Material
 
 
 def _sphere_point_to_uv(point: Point) -> Vec2d:
@@ -61,9 +62,10 @@ class Shape:
 
     """
 
-    def __init__(self, transformation=Transformation()):
+    def __init__(self, transformation: Transformation = Transformation(), material: Material = Material()):
         """Create a shape, potentially associating a transformation to it"""
         self.transformation = transformation
+        self.material = material
 
     def ray_intersection(self, ray: Ray) -> Union[HitRecord, None]:
         """Compute the intersection between a ray and this shape"""
@@ -112,4 +114,5 @@ class Sphere(Shape):
             surface_point=_sphere_point_to_uv(hit_point),
             t=first_hit_t,
             ray=ray,
+            shape=self,
         )

--- a/shapes.py
+++ b/shapes.py
@@ -114,7 +114,7 @@ class Sphere(Shape):
             surface_point=_sphere_point_to_uv(hit_point),
             t=first_hit_t,
             ray=ray,
-            shape=self,
+            material=self.material,
         )
 
 
@@ -147,5 +147,5 @@ class Plane(Shape):
             surface_point=Vec2d(hit_point.x - floor(hit_point.x), hit_point.y - floor(hit_point.y)),
             t=t,
             ray=ray,
-            shape=self,
+            material=self.material,
         )

--- a/shapes.py
+++ b/shapes.py
@@ -69,7 +69,7 @@ class Shape:
 
     def ray_intersection(self, ray: Ray) -> Union[HitRecord, None]:
         """Compute the intersection between a ray and this shape"""
-        return NotImplementedError(
+        raise NotImplementedError(
             "Shape.ray_intersection is an abstract method and cannot be called directly"
         )
 

--- a/shapes.py
+++ b/shapes.py
@@ -23,7 +23,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from math import sqrt, atan2, acos, pi
+from math import sqrt, atan2, acos, pi, floor
 from typing import Union
 from geometry import Point, Vec, Normal
 from hitrecord import Vec2d, HitRecord
@@ -113,6 +113,39 @@ class Sphere(Shape):
             normal=self.transformation * _sphere_normal(hit_point, inv_ray.dir),
             surface_point=_sphere_point_to_uv(hit_point),
             t=first_hit_t,
+            ray=ray,
+            shape=self,
+        )
+
+
+class Plane(Shape):
+    """A 3D infinite plane parallel to the x and y axis and passing through the origin."""
+
+    def __init__(self, transformation=Transformation(), material: Material = Material()):
+        """Create a xy plane, potentially associating a transformation to it"""
+        super().__init__(transformation, material)
+
+    def ray_intersection(self, ray: Ray) -> Union[HitRecord, None]:
+        """Checks if a ray intersects the plane
+
+        Return a `HitRecord`, or `None` if no intersection was found.
+        """
+        inv_ray = ray.transform(self.transformation.inverse())
+        if abs(inv_ray.dir.z) < 1e-5:
+            return None
+
+        t = -inv_ray.origin.z / inv_ray.dir.z
+
+        if (t <= inv_ray.tmin) or (t >= inv_ray.tmax):
+            return None
+
+        hit_point = inv_ray.at(t)
+
+        return HitRecord(
+            world_point=self.transformation * hit_point,
+            normal=self.transformation * Normal(0.0, 0.0, 1.0 if inv_ray.dir.z < 0.0 else -1.0),
+            surface_point=Vec2d(hit_point.x - floor(hit_point.x), hit_point.y - floor(hit_point.y)),
+            t=t,
             ray=ray,
             shape=self,
         )

--- a/test_all.py
+++ b/test_all.py
@@ -575,7 +575,7 @@ class TestSphere(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.0),
             t=1.0,
             ray=ray1,
-            shape=sphere,
+            material=sphere.material,
         ).is_close(intersection1)
 
         ray2 = Ray(origin=Point(3, 0, 0), dir=-VEC_X)
@@ -587,7 +587,7 @@ class TestSphere(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.5),
             t=2.0,
             ray=ray2,
-            shape=sphere,
+            material=sphere.material,
         ).is_close(intersection2)
 
         assert not sphere.ray_intersection(Ray(origin=Point(0, 10, 2), dir=-VEC_Z))
@@ -604,7 +604,7 @@ class TestSphere(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.5),
             t=1.0,
             ray=ray,
-            shape=sphere,
+            material=sphere.material,
         ).is_close(intersection)
 
     def testTransformation(self):
@@ -619,7 +619,7 @@ class TestSphere(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.0),
             t=1.0,
             ray=ray1,
-            shape=sphere,
+            material=sphere.material,
         ).is_close(intersection1)
 
         ray2 = Ray(origin=Point(13, 0, 0), dir=-VEC_X)
@@ -631,7 +631,7 @@ class TestSphere(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.5),
             t=2.0,
             ray=ray2,
-            shape=sphere,
+            material=sphere.material,
         ).is_close(intersection2)
 
         # Check if the sphere failed to move by trying to hit the untransformed shape
@@ -715,7 +715,7 @@ class TestPlane(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.0),
             t=1.0,
             ray=ray1,
-            shape=plane,
+            material=plane.material,
         ).is_close(intersection1)
 
         ray2 = Ray(origin=Point(0, 0, 1), dir=VEC_Z)
@@ -742,7 +742,7 @@ class TestPlane(unittest.TestCase):
             surface_point=Vec2d(0.0, 0.0),
             t=1.0,
             ray=ray1,
-            shape=plane,
+            material=plane.material,
         ).is_close(intersection1)
 
         ray2 = Ray(origin=Point(0, 0, 1), dir=VEC_Z)

--- a/test_all.py
+++ b/test_all.py
@@ -949,15 +949,11 @@ class TestPathTracer(unittest.TestCase):
                 emitted_radiance=UniformPigment(Color(1.0, 1.0, 1.0) * emitted_radiance),
             )
 
-            world.add(Sphere(material=enclosure_material, transformation=scaling(Vec(10.0, 10.0, 10.0))))
+            world.add(Sphere(material=enclosure_material))
 
-            image = HdrImage(1, 1)
-
-            camera = PerspectiveCamera(aspect_ratio=1.0)
-            tracer = ImageTracer(image=image, camera=camera)
             path_tracer = PathTracer(pcg=pcg, num_of_rays=1, world=world, max_depth=100, russian_roulette_limit=101)
 
-            ray = tracer.fire_ray(0, 0)
+            ray = Ray(origin=Point(0, 0, 0), dir=Vec(1, 0, 0))
             color = path_tracer(ray)
 
             expected = emitted_radiance / (1.0 - reflectance)

--- a/test_all.py
+++ b/test_all.py
@@ -49,7 +49,7 @@ from camera import OrthogonalCamera, PerspectiveCamera
 from ray import Ray
 from imagetracer import ImageTracer
 from hitrecord import HitRecord, Vec2d
-from shapes import Sphere
+from shapes import Sphere, Plane
 from misc import are_close
 from world import World
 from pcg import PCG
@@ -700,6 +700,77 @@ class TestSphere(unittest.TestCase):
 
         ray6 = Ray(origin=Point(2.0, 0.0, -0.5), dir=-VEC_X)
         assert sphere.ray_intersection(ray6).surface_point.is_close(Vec2d(0.0, 2 / 3))
+
+
+class TestPlane(unittest.TestCase):
+    def testHit(self):
+        plane = Plane()
+
+        ray1 = Ray(origin=Point(0, 0, 1), dir=-VEC_Z)
+        intersection1 = plane.ray_intersection(ray1)
+        assert intersection1
+        assert HitRecord(
+            world_point=Point(0.0, 0.0, 0.0),
+            normal=Normal(0.0, 0.0, 1.0),
+            surface_point=Vec2d(0.0, 0.0),
+            t=1.0,
+            ray=ray1,
+            shape=plane,
+        ).is_close(intersection1)
+
+        ray2 = Ray(origin=Point(0, 0, 1), dir=VEC_Z)
+        intersection2 = plane.ray_intersection(ray2)
+        assert not intersection2
+
+        ray3 = Ray(origin=Point(0, 0, 1), dir=VEC_X)
+        intersection3 = plane.ray_intersection(ray3)
+        assert not intersection3
+
+        ray4 = Ray(origin=Point(0, 0, 1), dir=VEC_Y)
+        intersection4 = plane.ray_intersection(ray4)
+        assert not intersection4
+
+    def testTransformation(self):
+        plane = Plane(transformation=rotation_y(angle_deg=90.0))
+
+        ray1 = Ray(origin=Point(1, 0, 0), dir=-VEC_X)
+        intersection1 = plane.ray_intersection(ray1)
+        assert intersection1
+        assert HitRecord(
+            world_point=Point(0.0, 0.0, 0.0),
+            normal=Normal(1.0, 0.0, 0.0),
+            surface_point=Vec2d(0.0, 0.0),
+            t=1.0,
+            ray=ray1,
+            shape=plane,
+        ).is_close(intersection1)
+
+        ray2 = Ray(origin=Point(0, 0, 1), dir=VEC_Z)
+        intersection2 = plane.ray_intersection(ray2)
+        assert not intersection2
+
+        ray3 = Ray(origin=Point(0, 0, 1), dir=VEC_X)
+        intersection3 = plane.ray_intersection(ray3)
+        assert not intersection3
+
+        ray4 = Ray(origin=Point(0, 0, 1), dir=VEC_Y)
+        intersection4 = plane.ray_intersection(ray4)
+        assert not intersection4
+
+    def testUVCoordinates(self):
+        plane = Plane()
+
+        ray1 = Ray(origin=Point(0, 0, 1), dir=-VEC_Z)
+        intersection1 = plane.ray_intersection(ray1)
+        assert intersection1.surface_point.is_close(Vec2d(0.0, 0.0))
+
+        ray2 = Ray(origin=Point(0.25, 0.75, 1), dir=-VEC_Z)
+        intersection2 = plane.ray_intersection(ray2)
+        assert intersection2.surface_point.is_close(Vec2d(0.25, 0.75))
+
+        ray3 = Ray(origin=Point(4.25, 7.75, 1), dir=-VEC_Z)
+        intersection3 = plane.ray_intersection(ray3)
+        assert intersection3.surface_point.is_close(Vec2d(0.25, 0.75))
 
 
 class TestWorld(unittest.TestCase):

--- a/test_all.py
+++ b/test_all.py
@@ -52,6 +52,7 @@ from hitrecord import HitRecord, Vec2d
 from shapes import Sphere
 from misc import are_close
 from world import World
+from pcg import PCG
 
 import pytest
 
@@ -716,6 +717,24 @@ class TestWorld(unittest.TestCase):
 
         assert intersection2
         assert intersection2.world_point.is_close(Point(9.0, 0.0, 0.0))
+
+
+class TestPCG(unittest.TestCase):
+    def test_random(self):
+        pcg = PCG()
+        assert pcg.state == 1753877967969059832
+        assert pcg.inc == 109
+
+        for expected in [
+            2707161783,
+            2068313097,
+            3122475824,
+            2211639955,
+            3215226955,
+            3421331566,
+        ]:
+            result = pcg.random()
+            assert expected == result
 
 
 if __name__ == "__main__":

--- a/world.py
+++ b/world.py
@@ -16,6 +16,8 @@
 # CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from typing import Union
+
 from hitrecord import HitRecord
 from ray import Ray
 from shapes import Shape
@@ -36,7 +38,7 @@ class World:
         """Append a new shape to this world"""
         self.shapes.append(shape)
 
-    def ray_intersection(self, ray: Ray) -> HitRecord:
+    def ray_intersection(self, ray: Ray) -> Union[HitRecord, None]:
         """Determine whether a ray intersects any of the objects in this world"""
         closest = None
 

--- a/world.py
+++ b/world.py
@@ -40,7 +40,7 @@ class World:
 
     def ray_intersection(self, ray: Ray) -> Union[HitRecord, None]:
         """Determine whether a ray intersects any of the objects in this world"""
-        closest = None
+        closest: Union[HitRecord, None] = None
 
         for shape in self.shapes:
             intersection = shape.ray_intersection(ray)
@@ -52,5 +52,8 @@ class World:
             if (not closest) or (intersection.t < closest.t):
                 # There was a hit, and it was closer than any other hit found before
                 closest = intersection
+
+        if closest:
+            closest.normal = closest.normal.normalize()
 
         return closest


### PR DESCRIPTION
This PR implements the types representing a BRDF and a simple path-tracer.

- [x] Add PCG random number generator
- [x] Add `Pigment`-related classes
- [x] Add `BRDF`-related classes
- [x] Add `Material`
- [x] Add `Renderer`
- [x] Implement a on/off tracer
- [x] Implement a flat tracer
- [x] Implement a path tracer
- [x] Modify the demo to showcase all the renderers
